### PR TITLE
Move archive plugin startup to archivecmd.Init

### DIFF
--- a/cmd/archivecmd/archive.go
+++ b/cmd/archivecmd/archive.go
@@ -21,9 +21,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/gohugoio/hugoreleaser/cmd/corecmd"
 	"github.com/gohugoio/hugoreleaser/internal/archives"
+	"github.com/gohugoio/hugoreleaser/internal/config"
+	"github.com/gohugoio/hugoreleaser/internal/plugins"
 	"github.com/gohugoio/hugoreleaser/plugins/archiveplugin"
 
 	"github.com/bep/logg"
@@ -65,6 +68,44 @@ func NewArchivist(core *corecmd.Core) *Archivist {
 
 func (b *Archivist) Init() error {
 	b.infoLog = b.core.InfoLog.WithField("cmd", commandName)
+	c := b.core
+
+	startAndRegister := func(p config.Plugin) error {
+		if p.IsZero() {
+			return nil
+		}
+		if _, found := c.PluginsRegistryArchive[p.ID]; found {
+			// Already started.
+			return nil
+		}
+		infoCtx := c.InfoLog.WithField("plugin", p.ID)
+		client, err := plugins.StartArchivePlugin(c.InfoLog, c.Config.GoSettings, p)
+		if err != nil {
+			return fmt.Errorf("error starting archive plugin %q: %w", p.ID, err)
+		}
+
+		// Send a heartbeat to the plugin to make sure it's alive.
+		heartbeat := fmt.Sprintf("heartbeat-%s", time.Now())
+		resp, err := client.Execute(archiveplugin.Request{Heartbeat: heartbeat})
+		if err != nil {
+			return fmt.Errorf("error testing archive plugin %q: %w", p.ID, err)
+		}
+		if resp.Heartbeat != heartbeat {
+			return fmt.Errorf("error testing archive plugin %q: unexpected heartbeat response", p.ID)
+		}
+		infoCtx.Log(logg.String("Archive plugin started and ready for use"))
+		c.PluginsRegistryArchive[p.ID] = client
+		return nil
+	}
+
+	if err := startAndRegister(c.Config.ArchiveSettings.Plugin); err != nil {
+		return err
+	}
+	for _, archive := range c.Config.Archives {
+		if err := startAndRegister(archive.ArchiveSettings.Plugin); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -101,10 +101,21 @@ func (b *Releaser) Exec(ctx context.Context, args []string) error {
 		return fmt.Errorf("%s: no releases defined in config", commandName)
 	}
 
-	logCtx := b.infoLog
-	if len(b.core.Paths) > 0 {
-		logCtx = b.infoLog.WithField("paths", b.core.Paths)
+	logFields := logg.Fields{
+		logg.Field{
+			Name: "tag", Value: b.core.Tag,
+		},
+		logg.Field{
+			Name: "commitish", Value: b.commitish,
+		},
 	}
+
+	if len(b.core.Paths) > 0 {
+		logFields = append(logFields, logg.Field{Name: "paths", Value: b.core.Paths})
+	}
+
+	logCtx := b.infoLog.WithFields(logFields)
+
 	logCtx.Log(logg.String("Finding releases"))
 	releaseMatches := b.core.Config.FindReleases(b.core.PathsReleasesCompiled)
 


### PR DESCRIPTION
To avoid starting it when not used.

I'm pretty sure I made that change before, but that got lost somehow.
