### PR TITLE
Add -chunks, -chunk-index to the build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ hugoreleaser archive
 hugoreleaser release
 ```
 
+The build command also takes the optional `-chunks` and `-chunk-index` which could be used to automatically split the builds to speed up pipelines., e.g. using [Circle CI's Job Splitting](https://circleci.com/docs/parallelism-faster-jobs#using-environment-variables-to-split-tests). **Note** that Hugo is in the process of setting this up, so it's a little early to tell how well this works in practice. 
+
 ## Plugins
 
 Hugoreleaser supports [Go Module](https://go.dev/blog/using-go-modules) plugins to create archives. See the [Deb Plugin](https://github.com/gohugoio/hugoreleaser-archive-plugins/tree/main/deb) for an example.

--- a/hugoreleaser.env
+++ b/hugoreleaser.env
@@ -1,6 +1,6 @@
 # Next release
-HUGORELEASER_TAG=v0.11.0
+HUGORELEASER_TAG=v0.12.0
 HUGORELEASER_COMMITISH=main
 
 # The planned next release title.
-HR_RELEASE_NAME=More improvements
+HR_RELEASE_NAME=Split the build in chunks

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -275,6 +276,40 @@ func TestMain(m *testing.M) {
 						fmt.Fprintf(os.Stderr, "%s is not executable\n", filename)
 						return -1
 					}
+				}
+
+				return 0
+			},
+			"checkfilecount": func() int {
+				if len(os.Args) != 3 {
+					fatalf("usage: checkfilecount count dir")
+				}
+
+				count, err := strconv.Atoi(os.Args[1])
+				if err != nil {
+					fatalf("invalid count: %v", err)
+				}
+				if count < 0 {
+					fatalf("count must be non-negative")
+				}
+				dir := os.Args[2]
+
+				found := 0
+
+				filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
+					if d.IsDir() {
+						return nil
+					}
+					found++
+					return nil
+				})
+
+				if found != count {
+					fmt.Fprintf(os.Stderr, "found %d files, want %d\n", found, count)
+					return -1
 				}
 
 				return 0

--- a/testscripts/misc/build_chunks.txt
+++ b/testscripts/misc/build_chunks.txt
@@ -1,0 +1,94 @@
+
+# There are 9 binaries in total.
+# These gets chunked into 4 chunks a 3,2,2,2.
+hugoreleaser build -tag v1.2.0 -chunk-index 0 -chunks 4
+! stderr .
+checkfilecount 3 $WORK/dist/hugo/v1.2.0/builds
+
+hugoreleaser build -tag v1.2.0 -chunk-index 1 -chunks 4
+checkfilecount 5 $WORK/dist/hugo/v1.2.0/builds
+
+hugoreleaser build -tag v1.2.0 -chunk-index 2 -chunks 4
+checkfilecount 7 $WORK/dist/hugo/v1.2.0/builds
+
+hugoreleaser build -tag v1.2.0 -chunk-index 3 -chunks 4
+checkfilecount 9 $WORK/dist/hugo/v1.2.0/builds
+
+! stderr .
+
+
+# Test files
+-- hugoreleaser.toml --
+project = "hugo"
+[build_settings]
+binary = "hugo"
+[archive_settings]
+name_template = "{{ .Project }}_{{ .Tag | trimPrefix `v` }}_{{ .Goos }}-{{ .Goarch }}"
+[archive_settings.type]
+format        = "tar.gz"
+extension = ".tar.gz"
+[archive_settings.replacements]
+amd64 ="64bit"
+386 = "32bit"
+arm64 = "ARM64"
+darwin = "macOS"
+windows = "Windows"
+[[builds]]
+path = "main/base"
+[builds.build_settings]
+env = ["CGO_ENABLED=0"]
+ldflags = "-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo=gohugoio"
+flags = ["-buildmode", "exe"]
+
+[[builds.os]]
+goos = "darwin"
+[[builds.os.archs]]
+goarch = "amd64"
+[[builds.os.archs]]
+goarch = "arm64"
+
+[[builds.os]]
+goos = "freebsd"
+[[builds.os.archs]]
+goarch = "amd64"
+[[builds.os.archs]]
+goarch = "arm64"
+
+[[builds.os]]
+goos = "linux"
+[[builds.os.archs]]
+goarch = "amd64"
+[[builds.os.archs]]
+goarch = "arm64"
+[[builds.os.archs]]
+goarch = "arm"
+
+[[builds.os]]
+goos = "windows"
+[builds.os.build_settings]
+binary = "hugo.exe"
+[[builds.os.archs]]
+goarch = "amd64"
+[[builds.os.archs]]
+goarch = "arm64"
+[[archives]]
+paths         = ["builds/**/{darwin,linux}/amd64"]
+[archives.archive_settings]
+[[archives]]
+paths         = ["builds/**/windows/*"]
+[archives.archive_settings]
+[archives.archive_settings.type]
+format = "zip"
+extension = ".zip"
+
+-- go.mod --
+module foo
+-- main.go --
+package main
+func main() {
+
+}
+-- README.md --
+This is readme.
+-- license.txt --
+This is license.


### PR DESCRIPTION
To partition the build step for greater parallelism.

The idea is to use this with Circle CI's `CIRCLE_NODE_INDEX` and
`CIRCLE_NODE_TOTAL`
env vars. How well/if that works out, time will tell.