### PR TITLE
Throw an error on duplicate archive names in a release

### DIFF
--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -187,21 +187,16 @@ func (b *Releaser) handleRelease(ctx context.Context, logCtx logg.LevelLogger, r
 	// First collect all files to be released.
 	var archiveFilenames []string
 
-	filter := release.PathsCompiled
-	for _, archive := range b.core.Config.Archives {
-		for _, archPath := range archive.ArchsCompiled {
-			if !filter.Match(archPath.Path) {
-				continue
-			}
-			archiveDir := filepath.Join(
-				b.core.DistDir,
-				b.core.Config.Project,
-				b.core.Tag,
-				b.core.DistRootArchives,
-				filepath.FromSlash(archPath.Path),
-			)
-			archiveFilenames = append(archiveFilenames, filepath.Join(archiveDir, archPath.Name))
-		}
+	for _, archPath := range release.ArchsCompiled {
+		archiveDir := filepath.Join(
+			b.core.DistDir,
+			b.core.Config.Project,
+			b.core.Tag,
+			b.core.DistRootArchives,
+			filepath.FromSlash(archPath.Path),
+		)
+		archiveFilenames = append(archiveFilenames, filepath.Join(archiveDir, archPath.Name))
+
 	}
 
 	if len(archiveFilenames) == 0 {

--- a/hugoreleaser.env
+++ b/hugoreleaser.env
@@ -1,6 +1,6 @@
 # Next release
-HUGORELEASER_TAG=v0.50.0
+HUGORELEASER_TAG=v0.51.0
 HUGORELEASER_COMMITISH=main
 
 # The planned next release title.
-HR_RELEASE_NAME=First usable release
+HR_RELEASE_NAME=v0.51.0 

--- a/internal/config/release_config.go
+++ b/internal/config/release_config.go
@@ -36,6 +36,9 @@ type Release struct {
 	ReleaseSettings ReleaseSettings `toml:"release_settings"`
 
 	PathsCompiled matchers.Matcher `toml:"-"`
+
+	// Builds matching Paths.
+	ArchsCompiled []BuildArchPath `toml:"-"`
 }
 
 func (a *Release) Init() error {

--- a/testscripts/misc/errors-release-duplicate-archive.txt
+++ b/testscripts/misc/errors-release-duplicate-archive.txt
@@ -1,0 +1,47 @@
+
+# It's possible (and easy) to create configurations which will produce two archives with the same name.
+# That may be relevant with multiple releases, but not within the same.
+# We need to detect that and throw an error.
+
+# Build binaries.
+! hugoreleaser all -tag v1.2.0 -commitish main -try
+stderr 'main/darwin/amd64.*main/darwin/arm64.*same archive name "hugoreleaser.tar.gz"'
+
+
+-- hugoreleaser.toml --
+project = "hugoreleaser"
+[build_settings]
+binary = "hugoreleaser"
+[release_settings]
+type = "github"
+repository = "hugoreleaser"
+repository_owner = "gohugoio"
+draft = true
+[release_settings.release_notes_settings]
+generate = true
+[archive_settings]
+# Deliberately simple to force duplicates.
+name_template = "{{ .Project }}"
+[archive_settings.type]
+format        = "tar.gz"
+extension = ".tar.gz"
+[[builds]]
+path = "main"
+[[builds.os]]
+goos = "darwin"
+[[builds.os.archs]]
+goarch = "amd64"
+[[builds.os.archs]]
+goarch = "arm64"
+[[archives]]
+paths = ["builds/**"]
+[[releases]]
+paths = ["archives/**"]
+path = "myrelease"
+-- go.mod --
+module foo
+-- main.go --
+package main
+func main() {
+
+}


### PR DESCRIPTION
This had me head scratching when testing this with Hugo yesterday, getting some weird 404 errors
from GitHub.

Note that this error will be thrown even with the `-try` flag, so you can do:

```
hugoreleaser all -tag v1.2.3 -commitish main -try
```

To do a basic verification of your setup.
