### PR TITLE
Shuffle chunked builds

### DIFF
--- a/cmd/buildcmd/build.go
+++ b/cmd/buildcmd/build.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 
@@ -102,6 +103,12 @@ func (b *Builder) Exec(ctx context.Context, args []string) error {
 	archs := b.core.Config.FindArchs(b.core.PathsBuildsCompiled)
 
 	if b.chunks > 0 {
+		// Resource-heavy builds tend to be configured in proximity to eachother,
+		// so this shuffle may help avoid clustering these slow builds in the same partition.
+		rand.Shuffle(len(archs), func(i, j int) {
+			archs[i], archs[j] = archs[j], archs[i]
+		})
+
 		partitions := slicehelpers.Chunk(archs, b.chunks)
 		if len(partitions) <= b.chunkIndex {
 			archs = nil

--- a/hugoreleaser.env
+++ b/hugoreleaser.env
@@ -3,4 +3,4 @@ HUGORELEASER_TAG=v0.51.0
 HUGORELEASER_COMMITISH=main
 
 # The planned next release title.
-HR_RELEASE_NAME=v0.51.0 
+HR_RELEASE_NAME=v0.51.0


### PR DESCRIPTION
Testing this feature on Circle CI, it works great, but I'm noticing that
reasource heavy builds (e.g. CGO builds and the MacOS universal builds)
tend to be configured together and end up in "resource heavy" partitions.

This commit shuffling the builds before the chunk operation, which should
improve this.
