### PR TITLE
Preserve the group order in change log

### DIFF
--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -147,6 +147,7 @@ func (b *Releaser) handleRelease(ctx context.Context, logCtx logg.LevelLogger, r
 	)
 
 	info := releases.ReleaseInfo{
+		Project:   b.core.Config.Project,
 		Tag:       b.core.Tag,
 		Commitish: b.commitish,
 		Settings:  release.ReleaseSettings,
@@ -365,12 +366,15 @@ func (b *Releaser) generateReleaseNotes(rctx releaseContext) (string, error) {
 }
 
 func (b *Releaser) generateChecksumTxt(rctx releaseContext, archiveFilenames ...string) (string, error) {
-	// Create a checksum.txt file.
+	// Create a checksums.txt file.
 	checksumLines, err := releases.CreateChecksumLines(b.core.Workforce, archiveFilenames...)
 	if err != nil {
 		return "", err
 	}
-	checksumFilename := filepath.Join(rctx.ReleaseDir, "checksum.txt")
+	// This is what Hugo got out of the box from Goreleaser. No settings for now.
+	name := fmt.Sprintf("%s_%s_checksums.txt", rctx.Info.Project, rctx.Info.Tag)
+
+	checksumFilename := filepath.Join(rctx.ReleaseDir, name)
 	err = func() error {
 		f, err := os.Create(checksumFilename)
 		if err != nil {

--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -296,16 +296,16 @@ func (b *Releaser) generateReleaseNotes(rctx releaseContext) (string, error) {
 		}
 	}
 
-	infosGrouped, err := changelog.GroupByTitleFunc(infos, func(change changelog.Change) (string, bool) {
-		for _, g := range changeGroups {
+	infosGrouped, err := changelog.GroupByTitleFunc(infos, func(change changelog.Change) (string, int, bool) {
+		for i, g := range changeGroups {
 			if g.RegexpCompiled.Match(change.Subject) {
 				if g.Ignore {
-					return "", false
+					return "", 0, false
 				}
-				return g.Title, true
+				return g.Title, i, true
 			}
 		}
-		return "", false
+		return "", 0, false
 	})
 
 	if err != nil {

--- a/internal/releases/changelog/changelog_test.go
+++ b/internal/releases/changelog/changelog_test.go
@@ -1,26 +1,26 @@
 package changelog
 
 import (
+	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 )
 
-//var isCI = os.Getenv("CI") != ""
+var isCI = os.Getenv("CI") != ""
 
 func TestGetOps(t *testing.T) {
-	t.Skip("TODO(bep) fix these once a new tag arrives.")
-	/*if isCI {
+	if isCI {
 		// GitHub Actions clones shallowly, so we can't test this there.
 		t.Skip("skip on CI")
-	}*/
+	}
 	c := qt.New(t)
 
-	tag, err := gitVersionTagBefore("", "v0.8.0")
+	tag, err := gitVersionTagBefore("", "v0.51.0")
 	c.Assert(err, qt.IsNil)
-	c.Assert(tag, qt.Equals, "v0.7.0")
+	c.Assert(tag, qt.Equals, "v0.50.0")
 
-	exists, err := gitTagExists("", "v0.8.0")
+	exists, err := gitTagExists("", "v0.50.0")
 	c.Assert(err, qt.IsNil)
 	c.Assert(exists, qt.Equals, true)
 
@@ -28,9 +28,9 @@ func TestGetOps(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(exists, qt.Equals, false)
 
-	log, err := gitLog("", "v0.6.0", "v0.7.0", "main")
+	log, err := gitLog("", "v0.50.0", "v0.51.0", "main")
 	c.Assert(err, qt.IsNil)
-	c.Assert(log, qt.Contains, "Consolidate the -paths flags")
+	c.Assert(log, qt.Contains, "Shuffle chunked builds")
 
 	infos, err := gitLogToGitInfos(log)
 	c.Assert(err, qt.IsNil)

--- a/internal/releases/client.go
+++ b/internal/releases/client.go
@@ -8,6 +8,7 @@ import (
 )
 
 type ReleaseInfo struct {
+	Project   string
 	Tag       string
 	Commitish string
 	Settings  config.ReleaseSettings

--- a/staticfiles/templates/release-notes.gotmpl
+++ b/staticfiles/templates/release-notes.gotmpl
@@ -3,6 +3,5 @@
 
 {{ range .Changes -}}
 * {{ .Subject }} {{ .Hash }}{{ with .Username }} @{{ . }}{{ end }} {{ range .Issues }}#{{ . }} {{ end }}
-{{ end -}}
-
+{{ end }}
 {{ end }}

--- a/testscripts/commands/release.txt
+++ b/testscripts/commands/release.txt
@@ -9,7 +9,7 @@ dostounix dist/hugo/v1.2.0/builds/main/base/darwin/arm64/hugo
 dostounix dist/hugo/v1.2.0/builds/main/base/darwin/amd64/hugo
 dostounix dist/hugo/v1.2.0/builds/main/base/linux/amd64/hugo
 dostounix dist/hugo/v1.2.0/builds/main/base/linux/arm/hugo
-dostounix expected/dist/myrelease/checksum.txt
+dostounix expected/dist/myrelease/checksums.txt
 
 # Build archives
 hugoreleaser archive -tag v1.2.0
@@ -18,17 +18,17 @@ exists $WORK/dist/hugo/v1.2.0/archives/main/base/darwin/amd64/hugo_1.2.0_macOS-6
 
 # Run with the a faketoken to avoid actually creating a remote release.
 hugoreleaser release -tag v1.2.0 -commitish main
-# 3 archives + checksum.txt
+# 3 archives + checksums.txt
 stdout 'Prepared 4 files to archive'
-stdout 'checksum\.txt'
-cmp $WORK/dist/hugo/v1.2.0/releases/myrelease/checksum.txt $WORK/expected/dist/myrelease/checksum.txt
+stdout 'hugo_v1.2.0_checksums\.txt'
+cmp $WORK/dist/hugo/v1.2.0/releases/myrelease/hugo_v1.2.0_checksums.txt $WORK/expected/dist/myrelease/checksums.txt
 
 # Test files
 # Release notes
 -- temp/my-release-notes.md --
 ## Release notes
 * Change 1
-# Fake binaries to get stable archive checksum.txt.
+# Fake binaries to get stable archive checksums.txt.
 -- dist/hugo/v1.2.0/builds/main/base/windows/amd64/hugo.exe --
 win-amd64
 -- dist/hugo/v1.2.0/builds/main/base/darwin/arm64/hugo --
@@ -41,7 +41,7 @@ linux-amd64
 linux-amd
 
 # Expected output
--- expected/dist/myrelease/checksum.txt --
+-- expected/dist/myrelease/checksums.txt --
 19c2308936cdc630dfb1c3620d54fc22dc072dd6d04f8aa0872963c3fb547572  hugo_1.2.0_Windows-64bit.zip
 8a49e492c1b787821fe81695617dcaf211ca3c0428094f3a4a4c1401678993a0  hugo_1.2.0_macOS-64bit.tar.gz
 df51345af47d4122b133055aa8bb6109cc47504026c29634b0a6e77f6aa7ebcf  hugo_1.2.0_linux-64bit.tar.gz

--- a/testscripts/misc/releasenotes-custom-template.txt
+++ b/testscripts/misc/releasenotes-custom-template.txt
@@ -1,8 +1,6 @@
 env GITHUB_TOKEN=faketoken
 env HUGORELEASER_CHANGELOG_GITREPO=$SOURCE
 
-skip # TODO(bep) fix me after next tag 
-
 # Build binaries.
 hugoreleaser all -tag v0.51.0 -commitish main
 ! stderr .
@@ -14,7 +12,7 @@ cmp $WORK/dist/hugoreleaser/v0.51.0/releases/myrelease/release-notes.md $WORK/ex
 -- mytemplates/custom.txt --
 {{ range .ChangeGroups }}{{ range .Changes }}Subject: {{ .Subject }}, Hash: {{ .Hash }}|{{ end }}{{ end }}
 -- expected/release-notes.md --
-Subject: Fix failing tests, Hash: a5c5562|
+Subject: Shuffle chunked builds, Hash: 515615e|Subject: Throw an error on duplicate archive names in a release, Hash: 8b4ede0|Subject: Fix failing tests, Hash: 130ca16|
 -- hugoreleaser.toml --
 project = "hugoreleaser"
 [build_settings]

--- a/testscripts/misc/releasenotes-short.txt
+++ b/testscripts/misc/releasenotes-short.txt
@@ -2,17 +2,20 @@ env GITHUB_TOKEN=faketoken
 env HUGORELEASER_CHANGELOG_GITREPO=$SOURCE
 
 # Build binaries.
-hugoreleaser all -tag v0.50.0 -commitish main
+hugoreleaser all -tag v0.51.0 -commitish main
 ! stderr .
 
-cmp $WORK/dist/hugoreleaser/v0.50.0/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
+cmp $WORK/dist/hugoreleaser/v0.51.0/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
 
 # Test files
 # Expected release notes
 -- expected/release-notes.md --
 ## Short release
 
-* Pull Chunk out into helpers a37d4dd 
+* Shuffle chunked builds 515615e 
+* Throw an error on duplicate archive names in a release 8b4ede0 
+* Fix failing tests 130ca16 
+
 
 -- hugoreleaser.toml --
 project = "hugoreleaser"

--- a/testscripts/misc/releasenotes.txt
+++ b/testscripts/misc/releasenotes.txt
@@ -2,18 +2,26 @@ env GITHUB_TOKEN=faketoken
 env HUGORELEASER_CHANGELOG_GITREPO=$SOURCE
 
 # Build binaries.
-hugoreleaser all -tag v0.50.0 -commitish main
+hugoreleaser all -tag v0.51.0 -commitish main
 ! stderr .
 
-cmp $WORK/dist/hugoreleaser/v0.50.0/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
+cmp $WORK/dist/hugoreleaser/v0.51.0/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
 
 # Test files
 # Expected release notes
-# TODO(bep) adjust this when a new release with more lines arrives.
 -- expected/release-notes.md --
-## What's Changed
+## First
 
-* Pull Chunk out into helpers a37d4dd 
+* Throw an error on duplicate archive names in a release 8b4ede0 
+
+## Second
+
+* Fix failing tests 130ca16 
+
+## Third
+
+* Shuffle chunked builds 515615e 
+
 
 -- hugoreleaser.toml --
 project = "hugoreleaser"
@@ -26,6 +34,11 @@ repository_owner = "gohugoio"
 draft = true
 [release_settings.release_notes_settings]
 generate = true
+groups = [
+            { title = "First", regexp = "error" },
+            { title = "Second", regexp = "failing" },
+            { title = "Third", regexp = "chunked" },
+]
 [archive_settings]
 name_template = "{{ .Project }}_{{ .Tag | trimPrefix `v` }}_{{ .Goos }}-{{ .Goarch }}"
 [archive_settings.type]

--- a/testscripts/misc/segments.txt
+++ b/testscripts/misc/segments.txt
@@ -18,7 +18,7 @@ stdout freebsd
 
 # We have now only freebsd 3 archives.
 hugoreleaser release -paths releases/bsd
-stdout 'Prepared 3 files' # 2 archives + checksum.txt.
+stdout 'Prepared 3 files' # 2 archives + checksums.txt.
 
 # Test files
 -- hugoreleaser.toml --


### PR DESCRIPTION
Also

* get the other tests back in shape.
* add a missing newline in the change log template

Fixes #23
