### PR TITLE
Reintroduce ordinal config on release notes

### DIFF
--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/bep/logg"
@@ -376,7 +377,7 @@ func (b *Releaser) generateChecksumTxt(rctx releaseContext, archiveFilenames ...
 		return "", err
 	}
 	// This is what Hugo got out of the box from Goreleaser. No settings for now.
-	name := fmt.Sprintf("%s_%s_checksums.txt", rctx.Info.Project, rctx.Info.Tag)
+	name := fmt.Sprintf("%s_%s_checksums.txt", rctx.Info.Project, strings.TrimPrefix(rctx.Info.Tag, "v"))
 
 	checksumFilename := filepath.Join(rctx.ReleaseDir, name)
 	err = func() error {

--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -303,7 +303,11 @@ func (b *Releaser) generateReleaseNotes(rctx releaseContext) (string, error) {
 				if g.Ignore {
 					return "", 0, false
 				}
-				return g.Title, i, true
+				ordinal := g.Ordinal
+				if ordinal == 0 {
+					ordinal = i + 1
+				}
+				return g.Title, ordinal, true
 			}
 		}
 		return "", 0, false

--- a/hugoreleaser.toml
+++ b/hugoreleaser.toml
@@ -62,14 +62,14 @@ project = "hugoreleaser"
             # Group the changes in the release notes by title.
             # You need at least one.
             # The groups will be tested in order until a match is found.
-            # The titles will so be listed in the given order in the release note.
-            # Any match with ignore=true title will be dropped.
+            # The titles will, by default, be listed in the given order in the release note.
+            # You can set an optional ordinal to adjust the order (as in the setup below).
+            # Any match with ignore=true will be dropped.
             { regexp = "snapcraft:|Merge commit|Squashed", ignore = true },
-            { title = "Bug fixes", regexp = "fix" },
-            { title = "Features", regexp = "(feat|improve|implement)" },
-            { title = "Dependency Updates", regexp = "deps" },
-            { title = "Documentation", regexp = "doc" },
-            { title = "Other", regexp = ".*" },
+            { title = "Bug fixes", regexp = "fix", ordinal = 20 },
+            { title = "Dependency Updates", regexp = "deps", ordinal = 30 },
+            { title = "Documentation", regexp = "doc", ordinal = 40 },
+            { title = "Improvements", regexp = ".*", ordinal = 10 },
         ]
 
 [[builds]]

--- a/internal/config/release_config.go
+++ b/internal/config/release_config.go
@@ -107,9 +107,10 @@ func (g *ReleaseNotesSettings) Init() error {
 }
 
 type ReleaseNotesGroup struct {
-	Title  string `toml:"title"`
-	Regexp string `toml:"regexp"`
-	Ignore bool   `toml:"ignore"`
+	Title   string `toml:"title"`
+	Regexp  string `toml:"regexp"`
+	Ignore  bool   `toml:"ignore"`
+	Ordinal int    `toml:"ordinal"`
 
 	RegexpCompiled matchers.Matcher `toml:"-"`
 }

--- a/testscripts/commands/release.txt
+++ b/testscripts/commands/release.txt
@@ -20,8 +20,8 @@ exists $WORK/dist/hugo/v1.2.0/archives/main/base/darwin/amd64/hugo_1.2.0_macOS-6
 hugoreleaser release -tag v1.2.0 -commitish main
 # 3 archives + checksums.txt
 stdout 'Prepared 4 files to archive'
-stdout 'hugo_v1.2.0_checksums\.txt'
-cmp $WORK/dist/hugo/v1.2.0/releases/myrelease/hugo_v1.2.0_checksums.txt $WORK/expected/dist/myrelease/checksums.txt
+stdout 'hugo_1.2.0_checksums\.txt'
+cmp $WORK/dist/hugo/v1.2.0/releases/myrelease/hugo_1.2.0_checksums.txt $WORK/expected/dist/myrelease/checksums.txt
 
 # Test files
 # Release notes


### PR DESCRIPTION
Turns out it was useful after all.
<
