### PR TITLE
fix/changelog patch 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ For the third option, you can set a custom release notes template to use in `tem
 
 If you need a Go build/release tool with all the bells and whistles, check out [GoReleaser](https://github.com/goreleaser/goreleaser). This project was created because [Hugo](https://github.com/gohugoio/hugo) needed some features not on the road map of that project. 
 
-Hugo used this tool for its [v0.102.0 Release](https://github.com/gohugoio/hugo/releases/tag/v0.102.0). If you also want to use this tool and have a complex setup, you may want to wait for a conclusion to [Issue #27](https://github.com/gohugoio/hugoreleaser/issues/27) first.
+Hugo has used this tool for all of its releases since [v0.102.0](https://github.com/gohugoio/hugo/releases/tag/v0.102.0).

--- a/cmd/releasecmd/release.go
+++ b/cmd/releasecmd/release.go
@@ -290,12 +290,15 @@ func (b *Releaser) generateReleaseNotes(rctx releaseContext) (string, error) {
 		if shortTitle == "" {
 			shortTitle = "What's Changed"
 		}
-		changeGroups = []config.ReleaseNotesGroup{
-			{
-				Title:          shortTitle,
-				RegexpCompiled: matchers.MatchEverything,
-			},
+		var changeGroupsShort []config.ReleaseNotesGroup
+		// Preserve any ignore groups.
+		for _, g := range changeGroups {
+			if g.Ignore {
+				changeGroupsShort = append(changeGroupsShort, g)
+			}
 		}
+		changeGroupsShort = append(changeGroupsShort, config.ReleaseNotesGroup{Title: shortTitle, RegexpCompiled: matchers.MatchEverything})
+		changeGroups = changeGroupsShort
 	}
 
 	infosGrouped, err := changelog.GroupByTitleFunc(infos, func(change changelog.Change) (string, int, bool) {

--- a/internal/releases/changelog/changelog.go
+++ b/internal/releases/changelog/changelog.go
@@ -228,7 +228,10 @@ func gitTagExists(repo, tag string) (bool, error) {
 }
 
 func gitVersionTagBefore(repo, ref string) (string, error) {
-	return gitShort(repo, "describe", "--tags", "--abbrev=0", "--always", "--match", "v[0-9]*", ref+"^")
+	if strings.HasPrefix(ref, "v") {
+		ref += "^"
+	}
+	return gitShort(repo, "describe", "--tags", "--abbrev=0", "--always", "--match", "v[0-9]*", ref)
 }
 
 var issueRe = regexp.MustCompile(`(?i)(?:Updates?|Closes?|Fix.*|See) #(\d+)`)

--- a/internal/releases/changelog/changelog_test.go
+++ b/internal/releases/changelog/changelog_test.go
@@ -37,3 +37,41 @@ func TestGetOps(t *testing.T) {
 	c.Assert(len(infos), qt.Equals, 3)
 
 }
+
+// Issue 30.
+func TestGetVersionTagBefore(t *testing.T) {
+	if isCI {
+		// GitHub Actions clones shallowly, so we can't test this there.
+		t.Skip("skip on CI")
+	}
+	c := qt.New(t)
+
+	for _, test := range []struct {
+		about  string
+		ref    string
+		expect string
+	}{
+		{
+			about:  "patch tag",
+			ref:    "v0.53.2",
+			expect: "v0.53.1",
+		},
+		{
+			about:  "patch commit",
+			ref:    "8509f4591d37435df1bfb2bcb4dfb5fe474b0252",
+			expect: "v0.53.2",
+		},
+		{
+			about:  "minor",
+			ref:    "v0.52.0",
+			expect: "v0.51.0",
+		},
+	} {
+		c.Run(test.about, func(c *qt.C) {
+			tag, err := gitVersionTagBefore("", test.ref)
+			c.Assert(err, qt.IsNil)
+			c.Assert(tag, qt.Equals, test.expect)
+		})
+	}
+
+}

--- a/testscripts/misc/releasenotes-short.txt
+++ b/testscripts/misc/releasenotes-short.txt
@@ -2,10 +2,10 @@ env GITHUB_TOKEN=faketoken
 env HUGORELEASER_CHANGELOG_GITREPO=$SOURCE
 
 # Build binaries.
-hugoreleaser all -tag v0.53.3 -commitish main
+hugoreleaser all -tag v0.53.2 -commitish main
 ! stderr .
 
-cmp $WORK/dist/hugoreleaser/v0.53.3/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
+cmp $WORK/dist/hugoreleaser/v0.53.2/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
 
 # Test files
 # Expected release notes
@@ -13,7 +13,6 @@ cmp $WORK/dist/hugoreleaser/v0.53.3/releases/myrelease/release-notes.md $WORK/ex
 ## Short release
 
 * testing: Cosmetic change5 to test patch releases 1a9c566 #30 
-* testing: Cosmetic change4 to test patch releases 74317ba #30 
 * testing: Cosmetic change3 to test patch releases 0ae1602 #30 
 
 
@@ -30,6 +29,9 @@ draft = true
 generate = true
 short_threshold = 10
 short_title = "Short release"
+groups = [
+{ regexp = "change4", ignore = true }          
+]
 [archive_settings]
 name_template = "{{ .Project }}_{{ .Tag | trimPrefix `v` }}_{{ .Goos }}-{{ .Goarch }}"
 [archive_settings.type]

--- a/testscripts/unfinished/releasenotes-short.txt
+++ b/testscripts/unfinished/releasenotes-short.txt
@@ -2,19 +2,19 @@ env GITHUB_TOKEN=faketoken
 env HUGORELEASER_CHANGELOG_GITREPO=$SOURCE
 
 # Build binaries.
-hugoreleaser all -tag v0.51.0 -commitish main
+hugoreleaser all -tag v0.53.3 -commitish main
 ! stderr .
 
-cmp $WORK/dist/hugoreleaser/v0.51.0/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
+cmp $WORK/dist/hugoreleaser/v0.53.3/releases/myrelease/release-notes.md $WORK/expected/release-notes.md
 
 # Test files
 # Expected release notes
 -- expected/release-notes.md --
 ## Short release
 
-* Shuffle chunked builds 515615e 
-* Throw an error on duplicate archive names in a release 8b4ede0 
-* Fix failing tests 130ca16 
+* testing: Cosmetic change5 to test patch releases 1a9c566 #30 
+* testing: Cosmetic change4 to test patch releases 74317ba #30 
+* testing: Cosmetic change3 to test patch releases 0ae1602 #30 
 
 
 -- hugoreleaser.toml --


### PR DESCRIPTION
- Fix gitVersionTagBefore
- Preserve changelog ignore groups in short mode
